### PR TITLE
fix: prevent duplicate matches with the same person

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Dating Clock
+# Gala With Me
 
 A Next.js application where users can match with others by selecting their preferred time on a clock interface and sharing QR codes.
 

--- a/app/components/qr-scanner.tsx
+++ b/app/components/qr-scanner.tsx
@@ -65,6 +65,16 @@ const QRScannerComponent = forwardRef<QRScannerRef, QRScannerProps>(({
             processingRef.current = true;
             setIsProcessing(true);
             
+            // bug fix: stop the scanner IMMEDIATELY to prevent multiple scans leading to misleading match errors after a successful one
+            if (qrScannerRef.current) {
+              try {
+                qrScannerRef.current.stop();
+                setIsScanning(false);
+              } catch (stopError) {
+                console.error("error stopping scanner immediately:", stopError);
+              }
+            }
+            
             // small delay to show the loading state, then process
             setTimeout(() => {
               onScanSuccessRef.current(result.data);

--- a/app/components/time-picker.tsx
+++ b/app/components/time-picker.tsx
@@ -95,6 +95,8 @@ export default function TimePicker({
       setShowModal(true);
     } catch (err) {
       console.error("Error fetching match details:", err);
+    } finally {
+      setIsModalLoading(false);
     }
   };
 
@@ -289,6 +291,20 @@ export default function TimePicker({
           pointer-events: auto;
         }
       `}</style>
+      
+      {/* Loading Modal */}
+      {isModalLoading && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
+          <div className="bg-white rounded-3xl shadow-2xl p-6 w-96">
+            <div className="flex flex-col items-center space-y-4">
+              <div className="animate-spin rounded-full h-12 w-12 border-4 border-orange-300 border-t-orange-600"></div>
+              <p className="text-orange-600 font-semibold">Loading match details...</p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Match Details Modal */}
       {showModal && matchedPair && (
         <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
           <div className="bg-white rounded-3xl shadow-2xl p-6 w-96 animate-pop">

--- a/app/components/time-picker.tsx
+++ b/app/components/time-picker.tsx
@@ -23,6 +23,10 @@ export default function TimePicker({
   onTimeSelect,
   isHourMatched,
 }: TimePickerProps) {
+  const [showModal, setShowModal] = useState(false);
+  const [matchedPair, setMatchedPair] = useState<MatchWithUsers | null>(null);
+  const [isModalLoading, setIsModalLoading] = useState(false);
+
   const updatePreferredTime = async (time: number) => {
 
     if (!user) return;
@@ -59,12 +63,11 @@ export default function TimePicker({
   const hours = [12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
   const selectedHour = getSelectedHour();
 
-     const [showModal, setShowModal] = useState(false);
-    const [matchedPair, setMatchedPair] = useState<MatchWithUsers | null>(null);
-
   const handlePopModal = async (hour: number) => {
     if (!isHourMatched || !isHourMatched(hour)) return;
 
+    setIsModalLoading(true);
+    
     try {
       // Fetch match with user details in a single query using joins
       const { data: matchData, error } = await supabase

--- a/app/hooks/useMatchHandling.ts
+++ b/app/hooks/useMatchHandling.ts
@@ -179,6 +179,19 @@ export function useMatchHandling({ user }: UseMatchHandlingProps) {
         return;
       }
 
+      // check if the two users already have a match (in both directions)
+      const { data: existingMatches} = await supabase
+        .from("matches")
+        .select("*")
+        .or(
+          `and(user1_id.eq.${user.id},user2_id.eq.${scannedUserId}),and(user1_id.eq.${scannedUserId},user2_id.eq.${user.id})`
+        );
+
+      if (existingMatches && existingMatches.length > 0) {
+        setError(`You can't match with the same person more than once!`);
+        return;
+      }
+
       // create a match
       const matchData = {
         user1_id: user.id,


### PR DESCRIPTION
this pr introduces a fix to the bug wherein if user a (qr scanner) scans and matches with user b (qr being scanned), it is still possible for them to match for the second time if they will switch roles and user b will now be the qr scanner (previously user a) and user a will be the one being scanned (previously user b). a bidirectional duplication check is added to prevent this issue from happening (now, the db checks two times),

"and(user1_id.eq.${user.id},user2_id.eq.${scannedUserId}),and(user1_id.eq.${scannedUserId},user2_id.eq.${user.id})"